### PR TITLE
Fixed typographical error, changed auxilary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ $response = $topic->delete($options);
 
 ### Feed api
 
-Returns api instance to get auxilary information about Buffer useful when creating your app.
+Returns api instance to get auxiliary information about Buffer useful when creating your app.
 
 The following arguments are required:
 


### PR DESCRIPTION
cwadding, I've corrected a typographical error in the documentation of the [sensit-php](https://github.com/cwadding/sensit-php) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
